### PR TITLE
Fixed three issues

### DIFF
--- a/src/face_editor.py
+++ b/src/face_editor.py
@@ -152,6 +152,17 @@ def select_idx(_, value):
 
 def part_lat_indices():
     idx = cc.vert_to_part[sel_idx][0]
+    
+    # Patchy fix to ensure we modify the correct latent part during optimization
+    if idx == 3:
+       idx = 4
+    elif idx == 6:
+       idx = 3
+    elif idx == 4:
+       idx = 0
+    elif idx == 0:
+       idx = 6
+       
     return idx * part_latent_size, idx * part_latent_size + part_latent_size
 
 # --------------------------------------------------------------------

--- a/src/face_extractor.py
+++ b/src/face_extractor.py
@@ -20,6 +20,9 @@ heads_path = 'empty'
 root = rf'{os.path.abspath(os.path.dirname(__file__))}/..'
 data_path = rf'{root}/data'
 
+# Ensure folder is created before writing to it
+if not os.path.exists(rf'{data_path}//mesh_data//faces'):
+    os.makedirs(rf'{data_path}//mesh_data//faces')
 
 vert_map = None
 part_dict = {}

--- a/src/part_extractor.py
+++ b/src/part_extractor.py
@@ -21,6 +21,9 @@ heads_path = 'empty'
 root = rf'{os.path.abspath(os.path.dirname(__file__))}/..'
 data_path = rf'{root}/data'
 
+# Ensure folder is created before writing to it
+if not os.path.exists(rf'{data_path}//mesh_data//parts'):
+    os.makedirs(rf'{data_path}//mesh_data//parts')
 
 part_dict = {}
 


### PR DESCRIPTION
### Folder issues
_face_extractor.py_ and _part_extractor.py_ crash if the two folders storing the faces and face parts are not manually created with the correct name. By default, the two programs crash if following the setup guide in README.

### Optimization issue
_face_editor.py_ does not optimize correctly the latent face parts by default. The latent part index linked to a set of vertices (face region) is incorrect. Example: the nose latent part is connected to the cheeks vertices of the face, which is incorrect and the optimization process does not work by default. The solution proposed is a little bit "patchy", but it solves the issue and local editing works.