### PR TITLE
Faces and part folders creation

### DIFF
--- a/src/face_extractor.py
+++ b/src/face_extractor.py
@@ -20,6 +20,9 @@ heads_path = 'empty'
 root = rf'{os.path.abspath(os.path.dirname(__file__))}/..'
 data_path = rf'{root}/data'
 
+# Ensure folder is created before writing to it
+if not os.path.exists(rf'{data_path}//mesh_data//faces'):
+    os.makedirs(rf'{data_path}//mesh_data//faces')
 
 vert_map = None
 part_dict = {}

--- a/src/part_extractor.py
+++ b/src/part_extractor.py
@@ -21,6 +21,9 @@ heads_path = 'empty'
 root = rf'{os.path.abspath(os.path.dirname(__file__))}/..'
 data_path = rf'{root}/data'
 
+# Ensure folder is created before writing to it
+if not os.path.exists(rf'{data_path}//mesh_data//parts'):
+    os.makedirs(rf'{data_path}//mesh_data//parts')
 
 part_dict = {}
 


### PR DESCRIPTION
Create _faces_ and _parts_ folders before writing data to them. Otherwise, it throws an error by default if the folders are not created manually.