### PR TITLE
Fix mixed-up latent space and training errors

### DIFF
--- a/core/utils_dataloader.py
+++ b/core/utils_dataloader.py
@@ -19,7 +19,7 @@ def load_face_and_parts(data_path, count, split=0.8):
         mesh = om.read_trimesh(rf'{data_path}/mesh_data/faces/face ({i}).obj')
         faces.append(mesh.points().astype('float32').flatten())
 
-        for path in glob(rf'{data_path}/parts_info/*'):
+        for path in sorted(glob(rf'{data_path}/parts_info/*')):
             part_name = os.path.basename(os.path.normpath(path)).split('.')[0]
 
             if part_name not in parts_map:
@@ -38,7 +38,7 @@ def load_face_and_parts(data_path, count, split=0.8):
     train_part_map = {}
     test_part_map = {}
 
-    for path in glob(rf'{data_path}/parts_info/*'):
+    for path in sorted(glob(rf'{data_path}/parts_info/*')):
         part_name = os.path.basename(os.path.normpath(path)).split('.')[0]
         scaler = StandardScaler()
         parts_map[part_name] = scaler.fit_transform(np.array(parts_map[part_name]))

--- a/src/face_editor.py
+++ b/src/face_editor.py
@@ -22,7 +22,7 @@ root = rf'{os.path.abspath(os.path.dirname(__file__))}/..'
 data_path = rf'{root}/data'
 out_dir = rf'{data_path}/out_face_model'
 
-model_path = rf'{data_path}/pretrained/model.pt'
+model_path = rf'{data_path}/out_face_model/checkpoints/checkpoint1_73.pt'
 
 logs_dir = out_dir + '/logs'
 checkpoints_dir = out_dir + '/checkpoints'
@@ -50,7 +50,7 @@ part_verts = []
 part_template = []
 vert_map = np.loadtxt(vert_map_path, dtype=np.uint32)
 
-for path in glob(parts_info_path):
+for path in sorted(glob(parts_info_path)):
     part_name = os.path.basename(os.path.normpath(path)).split('.')[0]
     verts = np.loadtxt(path, dtype=np.uint32)
     for idx, vert in enumerate(verts):

--- a/src/train.ipynb
+++ b/src/train.ipynb
@@ -55,7 +55,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "root = rf'{os.getcwd()}/..'\n",
+        "root = rf'{os.path.abspath(os.path.dirname(__file__))}/..'\n",
         "data_path = rf'{root}/data'"
       ]
     },
@@ -183,7 +183,7 @@
         "parts_template = []\n",
         "vert_map = np.loadtxt(rf'{data_path}/vert_map.csv', dtype=np.uint32)\n",
         "\n",
-        "for path in glob(rf'{data_path}/parts_info/*'):\n",
+        "for path in sorted(glob(rf'{data_path}/parts_info/*')):\n",
         "    verts = np.loadtxt(path, dtype=np.uint32)\n",
         "    for idx, vert in enumerate(verts):\n",
         "        verts[idx] = vert_map[vert]\n",

--- a/src/train.py
+++ b/src/train.py
@@ -26,7 +26,7 @@ device = torch.device('cpu' if FORCE_CPU else 'cuda', 0)
 print(device)
 
 
-root = rf'{os.getcwd()}/..'
+root = rf'{os.path.abspath(os.path.dirname(__file__))}/..'
 data_path = rf'{root}/data'
 out_dir = rf'{data_path}/out_face_model'
 logs_dir = out_dir + '/logs'
@@ -61,7 +61,7 @@ parts_names = []
 parts_template = []
 vert_map = np.loadtxt(rf'{data_path}/vert_map.csv', dtype=np.uint32)
 
-for path in glob(rf'{data_path}/parts_info/*'):
+for path in sorted(glob(rf'{data_path}/parts_info/*')):
     verts = np.loadtxt(path, dtype=np.uint32)
     for idx, vert in enumerate(verts):
         verts[idx] = vert_map[vert]
@@ -133,7 +133,7 @@ K = 6
 in_channels = 3
 part_latent_size = 8
 out_channels = [16, 32]
-epochs = 10
+epochs = 73
 
 lr = 8e-4
 lr_decay = 0.99


### PR DESCRIPTION
### Mixed-up latent space
Face parts need sorting in alphabetical order (Ubuntu / Linux mixed by default at editing time)

### Fix bad epochs number
_train.py_ by default sets number of epochs to 10 (73 paper recommendation)

### Fix bad folder and model checkpoint file name
Editing program picks-up wrong file by default and throws error

Now the entire program works from beginning to end without any manual tweaking.